### PR TITLE
feat: update the example and comment about `\varnothing`

### DIFF
--- a/undergradmath.typ
+++ b/undergradmath.typ
@@ -188,10 +188,15 @@ Get the set complement $A^(sans(c))$ with `A^(sans(c))` (or $A^(complement)$ wit
 //       The Math fonts provide the character \varnothing, an alternative to \emptyset,
 //     through Character Variant cv01. The fontsetup package provides the option
 //     'varnothing' to easily switch to the alternative character.
-//
-/ Remark: The character $Ø$ from `\varnothing` in #LaTeX is an alternative character of $nothing$ from `nothing` in Typst (`\emptyset` in #LaTeX).
-  See the Version 3.93 section of README at #link("https://www.ctan.org/tex-archive/fonts/newcomputermodern").
-  You can create the `\varnothing` character with a `let` binding using specific fonts.
+
+// https://mirrors.sustech.edu.cn/CTAN/fonts/newcomputermodern/doc/newcm-doc.pdf
+// The NewComputerModern FontFamily §13.3
+// The Math fonts provide the character \varnothing (⌀, U+2300), as an alternative to \emptyset (a slashed zero), through Character Variant cv01.
+// The fontsetup package provides the option ‘varnothing’ to easily switch to the alternative character.
+
+/ Remark: Using `diameter` for `\varnothing` may cause some confusion. However, #LaTeX also uses $diameter$ (`\u{2300}`) instead of $\u{2205}$ (`\u{2205}`), see #link("https://mirrors.sustech.edu.cn/CTAN/fonts/newcomputermodern/doc/newcm-doc.pdf")[newcm $section$13.3].
+  Another solution is to use `text(font: "Fira Sans", nothing)`, but the resultant glyph $text(font: "Fira Sans", nothing)$ is subtly different from the widely used one.
+  Ultimately, The choice is always *your decision*.
 
 = Decorations
 #align(center, table(

--- a/undergradmath.typ
+++ b/undergradmath.typ
@@ -168,7 +168,7 @@ Getting script letters is @unavailable.
   cell($subset$, `subset`), cell($bb(Q)$, [`QQ`, `bb(Q)`]), cell($not$, `not`),
   cell($subset.eq$, `subset.eq`), cell($bb(N)$, [`NN`, `bb(N)`]), cell($or$, `or`),
   cell($supset$, `supset`), cell($bb(C)$, [`CC`, `bb(C)`]), cell($and$, `and`),
-  cell($supset.eq$, `supset.eq`), cell($Ø$, [`Ø`@tricky]), cell($tack.r$, `tack.r`),
+  cell($supset.eq$, `supset.eq`), cell($diameter$, [`diameter`]), cell($tack.r$, `tack.r`),
   cell($in$, `in`), cell($nothing$, `nothing`), cell($models$, `models`),
   cell($in.not$, `in.not`), cell($alef$, `alef`), cell($without$, `without`),
 ))


### PR DESCRIPTION
I updated the example and comment about `\varnothing`.
+ To keep the output in 2 pages, I had to cut down the sentences, resulted in some loss of meaning.
+ It's important to note that copying text from a PDF may not give you the exact same Unicode characters, since the result also depends on the algorithm used for mapping character codes to Unicode values, as explained in [Stack Overflow](https://stackoverflow.com/questions/55478339/pdf-copy-text-issue-weird-characters). 
  + Nevertheless, I added a note that according to [newcm-doc](https://mirrors.sustech.edu.cn/CTAN/fonts/newcomputermodern/doc/newcm-doc.pdf), the Unicode code used for `\varnothing` is possible `U+2300`.

See related issue #10.