### PR TITLE
Update the document, the CI configuration and the documentation

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,17 @@
+name: Clean up
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "SemVer"
+        required: true
+        type: string
+jobs:
+  clean-up:
+    runs-on: macos-latest
+    steps:
+      - name: Delete the given tag and release
+        uses: dev-drprasad/delete-tag-and-release@v1.0
+        with:
+          tag_name: "v${{ inputs.version }}"
+          github_token: ${{ secrets.PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: macos-latest
     permissions:
       contents: write
-    env:
-      TYPST_ARCH: typst-x86_64-apple-darwin
     steps:
       - uses: actions/checkout@v3
       - name: Update Homebrew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,17 @@ on:
   push:
     tags:
       - 'v*.*.*'
-
 jobs:
   release:
     runs-on: macos-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Update Homebrew
         run: brew update
       - name: Install Typst
@@ -26,8 +29,21 @@ jobs:
         with:
           name: Undergradmath
           path: undergradmath.pdf
+      - name: Install git-cliff
+        run: brew install git-cliff
+      - name: Generate changelog
+        id: generate-changelog
+        run: |
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          git cliff -vv -s all -l >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          git cliff -vv -s all -l
+      - name: Print changelog
+        run: |
+          echo "${{ steps.generate-changelog.outputs.changelog }}"
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
+          body: ${{ steps.generate-changelog.outputs.changelog }}
           name: ${{ github.ref_name }}
           files: undergradmath.pdf

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,27 +1,81 @@
 name: Tag
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
-
+    inputs:
+      version:
+        description: "SemVer, use automatically generated version if omitted"
+        type: string
 jobs:
-  check-changed:
+  check-version:
     runs-on: macos-latest
     outputs:
-      modified_files: ${{ steps.changed-files.outputs.modified_files }}
+      modified: ${{ contains(steps.changed-files.outputs.modified_files, 'undergradmath.typ') }}
+      version: ${{ steps.output-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v3
-      - id: changed-files
-        uses: tj-actions/changed-files@v35
-
-  add-tag:
-    runs-on: macos-latest
-    needs: check-changed
-    if: github.event_name == 'workflow_dispatch' ||
-        contains(needs.check-changed.outputs.modified_files, 'undergradmath.typ')
-    steps:
-      - uses: actions/checkout@v3
-      - uses: mathieudutour/github-tag-action@v6.1
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Get previous tag
+        id: check-tag
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          dry_run: true
+          github_token: ${{ secrets.PAT }}
+      - name: Get base
+        id: get-base
+        run: |
+          echo -n "base=" >> $GITHUB_OUTPUT
+          git rev-list -n 1 "tags/${{ steps.check-tag.outputs.previous_tag }}" >> $GITHUB_OUTPUT
+      - name: Check changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v40
+        with:
+          base_sha: ${{ steps.get-base.outputs.base }}
+      - name: Output the version
+        id: output-version
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ steps.check-tag.outputs.new_version }}" >> $GITHUB_OUTPUT
+          fi
+      - name: List all modified files
+        run: |
+          echo "List all the files that have been modified: ${{ steps.changed-files.outputs.modified_files }}"
+  tag-changelog:
+    runs-on: macos-latest
+    needs: check-version
+    if: needs.check-version.outputs.modified == 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Update Homebrew
+        run: brew update
+      - name: Install git-cliff
+        run: brew install git-cliff
+      - name: Generate changelog
+        id: generate-changelog
+        run: |
+          git cliff -vv -t ${{ needs.check-version.outputs.version }} -o CHANGELOG.md
+      - name: Add changelog and commit
+        id: add-changelog
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: 'CHANGELOG.md'
+          author_name: github-actions[bot]
+          author_email: 41898282+github-actions[bot]@users.noreply.github.com
+          message: "release: update changelog for ${{ needs.check-version.outputs.version }} release"
+      - name: Add tag
+        uses: mathieudutour/github-tag-action@v6.1
+        if: steps.add-changelog.outputs.committed == 'true'
+        with:
+          commit_sha: ${{ steps.add-changelog.outputs.commit_long_sha }}
+          custom_tag: ${{ needs.check-version.outputs.version }}
           github_token: ${{ secrets.PAT }}

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -18,8 +18,6 @@ jobs:
     runs-on: macos-latest
     needs: check-changed
     if: contains(needs.check-changed.outputs.modified_files, 'undergradmath.typ')
-    env:
-      TYPST_ARCH: typst-x86_64-apple-darwin
     steps:
       - uses: actions/checkout@v3
       - name: Update Homebrew

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -3,23 +3,28 @@ on:
   push:
     branches-ignore:
       - main
-
+  pull_request:
 jobs:
   check-changed:
     runs-on: macos-latest
     outputs:
-      modified_files: ${{ steps.changed-files.outputs.modified_files }}
+      modified: ${{ contains(steps.changed-files.outputs.modified_files, 'undergradmath.typ') }}
     steps:
-      - uses: actions/checkout@v3
-      - id: changed-files
-        uses: tj-actions/changed-files@v35
-
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v40
+      - name: List all modified files
+        run: |
+          echo "List all the files that have been modified: ${{ steps.changed-files.outputs.modified_files }}"
   build-pdf:
     runs-on: macos-latest
     needs: check-changed
-    if: contains(needs.check-changed.outputs.modified_files, 'undergradmath.typ')
+    if: needs.check-changed.outputs.modified == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Update Homebrew
         run: brew update
       - name: Install Typst

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The following limitations are also annotated in the [document][latest-release].
 - [x] ~LaTeX arrays (i.e., matrices without fences) are unavailable, but it's easy to get them with the `grid` function.
       For math mode, it would be nice to add a new option `""` for `delim` of the `mat` function.~
       It's actually available with `$mat(delim: #none, ..)$`.
-- [ ] No idea with spacing between values and units. It would be really great to have something like [siunitx].
+- [ ] ~No idea with spacing between values and units. It would be really great to have something like [siunitx].~
+      There are in fact some amazing Typst ports of siunitx, such as [metro] and [unify].
 
 ## License
 [Like undergradmath], typst-undergradmath is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa].
@@ -35,10 +36,12 @@ The following limitations are also annotated in the [document][latest-release].
 [#2]: https://github.com/johanvx/typst-undergradmath/issues/2
 [#10]: https://github.com/johanvx/typst-undergradmath/issues/10
 [#16]: https://github.com/johanvx/typst-undergradmath/pull/16
+[Like undergradmath]: https://gitlab.com/jim.hefferon/undergradmath/-/blob/5b19eff74454f7c71664f85e8042d7b30fcf9cfb/LICENSE
+[Typst]: https://github.com/typst/typst
 [cc-by-sa]: http://creativecommons.org/licenses/by-sa/4.0/
 [latest-release]: https://github.com/johanvx/typst-undergradmath/releases/latest
-[Like undergradmath]: https://gitlab.com/jim.hefferon/undergradmath/-/blob/5b19eff74454f7c71664f85e8042d7b30fcf9cfb/LICENSE
 [mathabx]: https://www.ctan.org/tex-archive/fonts/mathabx
+[metro]: https://github.com/fenjalien/metro
 [siunitx]: https://www.ctan.org/pkg/siunitx
-[Typst]: https://github.com/typst/typst
 [undergradmath]: https://gitlab.com/jim.hefferon/undergradmath
+[unify]: https://github.com/ChHecker/unify

--- a/undergradmath.typ
+++ b/undergradmath.typ
@@ -13,7 +13,6 @@
 // Some horizontal spacing
 #let kern(length) = h(length, weak: true)
 #let enspace = kern(0.5em)
-#let qquad = h(2em)
 
 // For table/grid, something like "lhs \enspace rhs"
 #let cell(lhs, rhs) = box(lhs + enspace + rhs)
@@ -308,7 +307,7 @@ The right arrows in the first column have matching left arrows, such as `arrow.l
 = Variable-sized operators
 The summation $sum_(j = 0)^3 j^2$ `sum_(j = 0)^3 j^2` and the integral $integral_(x = 0)^3 x^2 dif x$ `integral_(x = 0)^3 x^2 dif x` expand when displayed.
 
-$ sum_(j = 0)^3 j^2 qquad integral_(x = 0)^3 x^2 dif x $
+$ sum_(j = 0)^3 j^2 wide integral_(x = 0)^3 x^2 dif x $
 
 These do the same.
 
@@ -435,9 +434,9 @@ Definition by cases can be easily obtained with the `cases` function.
 = Spacing in mathematics
 Improve $sqrt(2) x$ to $sqrt(2) thin x$ with a thin space, as in `sqrt(2) thin x`.
 Slightly wider are `medium` and `thick` (the three are in ratio $3 : 4 : 5$).
-Bigger space is `quad` for $arrow.r quad arrow.l$, which is useful between parts of a display.
+Bigger space are: `quad` for $-> quad <-$ and `wide` for $-> wide <-$, which are useful between parts of a display.
 Get arbitrary space with the `h` function.
-For example, use `#h(2em)` for `\qquad` in #LaTeX and `#h(-0.1667em)` for `\!`.
+For example, use `#h(-0.1667em)` for `\!` in #LaTeX.
 
 = Displayed equations
 Display equations in a block level using `$ ... $` with at least one space separating the math content and the `$`.

--- a/undergradmath.typ
+++ b/undergradmath.typ
@@ -83,7 +83,7 @@
   #text(large, headcolor)[*Typst Math for Undergrads*]
 ])
 
-This is a Typst port of _#LaTeX Math for Undergrads_ by Jim Hefferon.
+This is a Typst port with typst #sys.version of _#LaTeX Math for Undergrads_ by Jim Hefferon.
 The original version is available at #link("https://gitlab.com/jim.hefferon/undergradmath").
 
 = Meaning of annotations

--- a/undergradmath.typ
+++ b/undergradmath.typ
@@ -41,7 +41,7 @@
 #let date = datetime.today().display()
 
 // Unavailable (last check date)
-#show "??": box(text(red, [#date #emoji.crossmark]))
+#show "??": box(text(red, [v#sys.version #emoji.crossmark]))
 // Tricky
 #show "!!": box(text(blue, emoji.drops))
 // No idea
@@ -90,7 +90,7 @@ The original version is available at #link("https://gitlab.com/jim.hefferon/unde
 #figure(
   table(
     columns: (1fr, 2fr),
-    [??], [Unavailable. Last check on #date.],
+    [??], [Unavailable until typst #sys.version.],
   )
 ) <unavailable>
 #figure(


### PR DESCRIPTION
This PR contains multiple changes brought by [Typst v0.9.0](https://typst.app/docs/changelog/#v0.9.0).

- Replace the custom `qquad` with newly introduced `wide`
- Mention the compiler version in the document. Closes #30.

This PR also improves the CI configuration.

- Support generating CHANGELOG.md and the changelog for release notes automatically. Closes #24.
- Support manual tagging. Note that pushes into main don't trigger tagging any more.
- Support deleting tags and associated releases.

In addition, this PR updates the documentation.

- Mention some packages dedicated to typesetting units.