### PR TITLE
Try to bypass the protection rule again

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -69,8 +69,8 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           add: 'CHANGELOG.md'
-          author_name: johanvx
-          author_email: 61529310+johanvx@users.noreply.github.com
+          author_name: github-actions[bot]
+          author_email: 41898282+github-actions[bot]@users.noreply.github.com
           message: "release: update changelog for ${{ needs.check-version.outputs.version }} release"
       - name: Add tag
         uses: mathieudutour/github-tag-action@v6.1

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          token: ${{ secrets.PAT }}
       - name: Update Homebrew
         run: brew update
       - name: Install git-cliff


### PR DESCRIPTION
Let's see if this works in the future...

If not, I still need to temporarily disable the protection rule before running the tag workflow.