### PR TITLE
feat: add script letters

### DIFF
--- a/undergradmath.typ
+++ b/undergradmath.typ
@@ -136,7 +136,8 @@ Use as in `$cal(A)$`.
 
 $ cal(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z) $
 
-Getting script letters is @unavailable.
+#show math.equation: set text(stylistic-set: 1)
+Get script letters, such as $cal(P)$ from `$cal(P)$`, by changing the `stylistic-set` parameter of `text()` to the corresponding set.
 
 = Greek
 #align(center, table(

--- a/undergradmath.typ
+++ b/undergradmath.typ
@@ -48,7 +48,7 @@
 #show "?!": box(text(orange, [No idea #emoji.face.unhappy]))
 // Tricky figure numbering
 #set figure(numbering: n => {
-  ([??], [!!], [?!]).at(n - 1)
+  ([??], [!!], [?!]).at(n)
 })
 // No prefix
 #set ref(supplement: "")
@@ -87,12 +87,12 @@ This is a Typst port with typst #sys.version of _#LaTeX Math for Undergrads_ by 
 The original version is available at #link("https://gitlab.com/jim.hefferon/undergradmath").
 
 = Meaning of annotations
-#figure(
-  table(
-    columns: (1fr, 2fr),
-    [??], [Unavailable until typst #sys.version.],
-  )
-) <unavailable>
+// #figure(
+//  table(
+//    columns: (1fr, 2fr),
+//    [??], [Unavailable until typst #sys.version.],
+//  )
+// ) <unavailable>
 #figure(
   table(
     columns: (1fr, 2fr),


### PR DESCRIPTION
Getting script letters akin to `$\mathscr(P)$` is actually possible in Typst. It consists of changing the `stylistic-set` of the `text()` function to swap out the normal calligraphic set unicode range.

Which set that is, depends on the font used. In this case it's 1. Adding this sentence would offset the footer and move it to a third page but I propose just removing the `unavailable` annotation as it is no longer needed after this and puts everything neatly back into two pages.