### PR TITLE
Update to Typst v0.13.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build PDF
         run: typst compile undergradmath.typ
       - name: Upload PDF as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Undergradmath
           path: undergradmath.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,7 @@ jobs:
       - name: Install Typst
         run: brew install typst
       - name: Install fonts
-        run: |
-          brew tap homebrew/cask-fonts
-          brew install --cask font-twitter-color-emoji
+        run: brew install --cask font-twitter-color-emoji
       - name: Build PDF
         run: typst compile undergradmath.typ
       - name: Upload PDF as artifact

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-tags: true
       - name: Get previous tag
         id: check-tag
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           dry_run: true
           github_token: ${{ secrets.PAT }}
@@ -74,7 +74,7 @@ jobs:
           author_email: 41898282+github-actions[bot]@users.noreply.github.com
           message: "release: update changelog for ${{ needs.check-version.outputs.version }} release"
       - name: Add tag
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@v6.2
         if: steps.add-changelog.outputs.committed == 'true'
         with:
           commit_sha: ${{ steps.add-changelog.outputs.commit_long_sha }}

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -30,9 +30,7 @@ jobs:
       - name: Install Typst
         run: brew install typst
       - name: Install fonts
-        run: |
-          brew tap homebrew/cask-fonts
-          brew install --cask font-twitter-color-emoji
+        run: brew install --cask font-twitter-color-emoji
       - name: Build PDF
         run: typst compile undergradmath.typ
       - name: Upload PDF as artifact

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build PDF
         run: typst compile undergradmath.typ
       - name: Upload PDF as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Undergradmath
           path: undergradmath.pdf

--- a/undergradmath.typ
+++ b/undergradmath.typ
@@ -42,20 +42,20 @@
 #set table(stroke: none, align: horizon + left, inset: 0pt, row-gutter: 0.45em)
 
 // LaTeX and TeX logos
-#let TeX = style(styles => {
-  let e = measure(text(normalsize, "E"), styles)
+#let TeX = context {
+  let e = measure(text(normalsize, "E"))
   let T = "T"
   let E = text(normalsize, baseline: e.height / 2, "E")
   let X = "X"
   box(T + kern(-0.1667em) + E + kern(-0.125em) + X)
-})
-#let LaTeX = style(styles => {
-  let l = measure(text(10pt, "L"), styles)
-  let a = measure(text(7pt, "A"), styles)
+}
+#let LaTeX = context {
+  let l = measure(text(10pt, "L"))
+  let a = measure(text(7pt, "A"))
   let L = "L"
   let A = text(7pt, baseline: a.height - l.height, "A")
   box(L + kern(-0.36em) + A + kern(-0.15em) + TeX)
-})
+}
 
 // Unavailable (last check version)
 #show "??": box(text(red, [v#sys.version #emoji.crossmark]))

--- a/undergradmath.typ
+++ b/undergradmath.typ
@@ -15,13 +15,13 @@
         block(
           inset: 4pt,
           stroke: (top: headcolor),
-          text(headcolor)[johanvx (https://github.com/johanvx) #h(1fr) #datetime.today().display()]
-        )
+          text(headcolor)[johanvx (https://github.com/johanvx) #h(1fr) #datetime.today().display()],
+        ),
       )
     } else {
       []
     }
-  }
+  },
 )
 
 // Font size
@@ -64,9 +64,11 @@
 // No idea
 #show "?!": box(text(orange, [No idea #emoji.face.unhappy]))
 // Tricky figure numbering
-#set figure(numbering: n => {
-  ([??], [!!], [?!]).at(n)
-})
+#set figure(
+  numbering: n => {
+    ([??], [!!], [?!]).at(n)
+  },
+)
 // No prefix
 #set ref(supplement: "")
 
@@ -74,13 +76,11 @@
 #set par(justify: true)
 
 // Run-in sections, like LaTeX \paragraph
-#show heading.where(
-  level: 1
-): it => text(
+#show heading.where(level: 1): it => text(
   size: normalsize,
   weight: "bold",
   fill: headcolor,
-  it.body + h(0.67em)
+  it.body + h(0.67em),
 )
 
 // Black raw code
@@ -90,9 +90,12 @@
 #show: rest => columns(2, rest)
 
 // Title
-#align(center, link("https://github.com/johanvx/typst-undergradmath")[
-  #text(large, headcolor)[*Typst Math for Undergrads*]
-])
+#align(
+  center,
+  link("https://github.com/johanvx/typst-undergradmath")[
+    #text(large, headcolor)[*Typst Math for Undergrads*]
+  ],
+)
 
 // Put this here to avoid affecting the title
 #show link: underline
@@ -111,7 +114,7 @@ The original version is available at #link("https://gitlab.com/jim.hefferon/unde
   table(
     columns: (1fr, 2fr),
     [!!], [Tricky. A simpler method is needed.],
-  )
+  ),
 ) <tricky>
 // #figure(
 //   table(
@@ -135,15 +138,18 @@ Your document should contain at least this.
 )
 
 = Common constructs
-#align(center, table(
-  columns: 4,
-  align: (right, left, right, left),
-  column-gutter: (1em, 1.5em, 1em),
-  [$x^2$], [`x^2`],
-  [$sqrt(2)$, $root(n, 3)$], [`sqrt(2)`, `root(n, 3)`],
-  [$x_(i, j)$], [`x_(i, j)`],
-  [$2 / 3$, $2 \/ 3$], [`2 / 3`, `2 \/ 3` or `2 slash 3`], // Maybe use `slash`?
-))
+#align(
+  center,
+  table(
+    columns: 4,
+    align: (right, left, right, left),
+    column-gutter: (1em, 1.5em, 1em),
+    [$x^2$], [`x^2`],
+    [$sqrt(2)$, $root(n, 3)$], [`sqrt(2)`, `root(n, 3)`],
+    [$x_(i, j)$], [`x_(i, j)`],
+    [$2 / 3$, $2 \/ 3$], [`2 / 3`, `2 \/ 3` or `2 slash 3`], // Maybe use `slash`?
+  ),
+)
 
 = Calligraphic letters
 Use as in `$cal(A)$`.
@@ -154,41 +160,57 @@ $ cal(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z) $
 Get script letters, such as $cal(P)$ from `$cal(P)$`, by changing the `stylistic-set` parameter of `text()` to the corresponding set.
 
 = Greek
-#align(center, table(
-  columns: 4,
-  align: (right, left, right, left),
-  column-gutter: (1em, 1.5em, 1em),
-  [$alpha$], [`alpha`], [$xi$, $Xi$], [`xi`, `Xi`],
-  [$beta$], [`beta`], [$omicron$], [`omicron`],
-  [$gamma$, $Gamma$], [`gamma`, `Gamma`], [$pi$, $Pi$], [`pi`, `Pi`],
-  [$delta$, $Delta$], [`delta`, `Delta`], [$pi.alt$], [`pi.alt`],
-  [$epsilon.alt$], [`epsilon.alt`], [$rho$], [`rho`],
-  [$epsilon$], [`epsilon`], [$rho.alt$], [`rho.alt`],
-  [$zeta$], [`zeta`], [$sigma$, $Sigma$], [`sigma`, `Sigma`],
-  [$eta$], [`eta`], [$sigma.alt$], [`sigma.alt`],
-  [$theta$, $Theta$], [`theta`, `Theta`], [$tau$], [`tau`],
-  [$theta.alt$], [`theta.alt`], [$upsilon$, $Upsilon$], [`upsilon`, `Upsilon`],
-  [$iota$], [`iota`], [$phi.alt$, $Phi$], [`phi.alt`, `Phi`],
-  [$kappa$], [`kappa`], [$phi$], [`phi`],
-  [$lambda$, $Lambda$], [`lambda`, `Lambda`], [$chi$], [`chi`],
-  [$mu$], [`mu`], [$psi$, $Psi$], [`psi`, `Psi`],
-  [$nu$], [`nu`], [$omega$, $Omega$], [`omega`, `Omega`],
-))
+#align(
+  center,
+  table(
+    columns: 4,
+    align: (right, left, right, left),
+    column-gutter: (1em, 1.5em, 1em),
+    [$alpha$], [`alpha`], [$xi$, $Xi$], [`xi`, `Xi`],
+    [$beta$], [`beta`], [$omicron$], [`omicron`],
+    [$gamma$, $Gamma$], [`gamma`, `Gamma`], [$pi$, $Pi$], [`pi`, `Pi`],
+    [$delta$, $Delta$], [`delta`, `Delta`], [$pi.alt$], [`pi.alt`],
+    [$epsilon.alt$], [`epsilon.alt`], [$rho$], [`rho`],
+    [$epsilon$], [`epsilon`], [$rho.alt$], [`rho.alt`],
+    [$zeta$], [`zeta`], [$sigma$, $Sigma$], [`sigma`, `Sigma`],
+    [$eta$], [`eta`], [$sigma.alt$], [`sigma.alt`],
+    [$theta$, $Theta$], [`theta`, `Theta`], [$tau$], [`tau`],
+    [$theta.alt$],
+    [`theta.alt`],
+    [$upsilon$, $Upsilon$],
+    [`upsilon`, `Upsilon`],
+
+    [$iota$], [`iota`], [$phi.alt$, $Phi$], [`phi.alt`, `Phi`],
+    [$kappa$], [`kappa`], [$phi$], [`phi`],
+    [$lambda$, $Lambda$], [`lambda`, `Lambda`], [$chi$], [`chi`],
+    [$mu$], [`mu`], [$psi$, $Psi$], [`psi`, `Psi`],
+    [$nu$], [`nu`], [$omega$, $Omega$], [`omega`, `Omega`],
+  ),
+)
 
 = Sets and logic
-#align(center, table(
-  columns: 6,
-  align: (right, left, right, left, right, left),
-  column-gutter: (1em, 1.5em, 1em, 1.5em, 1em),
-  [$union$], [`union`], [$RR$], [`RR`, `bb(R)`], [$forall$], [`forall`],
-  [$inter$], [`inter`], [$bb(Z)$], [`ZZ`, `bb(Z)`], [$exists$], [`exists`],
-  [$subset$], [`subset`], [$bb(Q)$], [`QQ`, `bb(Q)`], [$not$], [`not`],
-  [$subset.eq$], [`subset.eq`], [$bb(N)$], [`NN`, `bb(N)`], [$or$], [`or`],
-  [$supset$], [`supset`], [$bb(C)$], [`CC`, `bb(C)`], [$and$], [`and`],
-  [$supset.eq$], [`supset.eq`], [$diameter$], [`diameter`], [$tack.r$], [`tack.r`],
-  [$in$], [`in`], [$nothing$], [`nothing`], [$models$], [`models`],
-  [$in.not$], [`in.not`], [$alef$], [`alef`], [$without$], [`without`],
-))
+#align(
+  center,
+  table(
+    columns: 6,
+    align: (right, left, right, left, right, left),
+    column-gutter: (1em, 1.5em, 1em, 1.5em, 1em),
+    [$union$], [`union`], [$RR$], [`RR`, `bb(R)`], [$forall$], [`forall`],
+    [$inter$], [`inter`], [$bb(Z)$], [`ZZ`, `bb(Z)`], [$exists$], [`exists`],
+    [$subset$], [`subset`], [$bb(Q)$], [`QQ`, `bb(Q)`], [$not$], [`not`],
+    [$subset.eq$], [`subset.eq`], [$bb(N)$], [`NN`, `bb(N)`], [$or$], [`or`],
+    [$supset$], [`supset`], [$bb(C)$], [`CC`, `bb(C)`], [$and$], [`and`],
+    [$supset.eq$],
+    [`supset.eq`],
+    [$diameter$],
+    [`diameter`],
+    [$tack.r$],
+    [`tack.r`],
+
+    [$in$], [`in`], [$nothing$], [`nothing`], [$models$], [`models`],
+    [$in.not$], [`in.not`], [$alef$], [`alef`], [$without$], [`without`],
+  ),
+)
 
 Negate an operator, as in $subset.not$, with `subset.not`.
 Get the set complement $A^(sans(c))$ with `A^(sans(c))` (or $A^(complement)$ with `A^(complement)`, or $overline(A)$ with `overline(A)`).
@@ -221,14 +243,34 @@ Get the set complement $A^(sans(c))$ with `A^(sans(c))` (or $A^(complement)$ wit
   Other solutions can be found in #link("https://sitandr.github.io/typst-examples-book/book/basics/math/symbols.html#empty-set")[Typst Examples Book].
 
 = Decorations
-#align(center, table(
-  columns: 6,
-  align: (right, left, right, left, right, left),
-  column-gutter: (1em, 1.5em, 1em, 1.5em, 1em),
-  [$f'$], [`f'`, `f prime`], [$dot(a)$], [`dot(a)`], [$tilde(a)$], [`tilde(a)`],
-  [$f prime.double$], [`f prime.double`], [$diaer(a)$], [`diaer(a)`], [$macron(a)$], [`macron(a)`],
-  [$Sigma^*$], [`Sigma^*`], [$hat(a)$], [`hat(a)`], [$arrow(a)$], [`arrow(a)`],
-))
+#align(
+  center,
+  table(
+    columns: 6,
+    align: (right, left, right, left, right, left),
+    column-gutter: (1em, 1.5em, 1em, 1.5em, 1em),
+    [$f'$],
+    [`f'`, `f prime`],
+    [$dot(a)$],
+    [`dot(a)`],
+    [$tilde(a)$],
+    [`tilde(a)`],
+
+    [$f prime.double$],
+    [`f prime.double`],
+    [$diaer(a)$],
+    [`diaer(a)`],
+    [$macron(a)$],
+    [`macron(a)`],
+
+    [$Sigma^*$],
+    [`Sigma^*`],
+    [$hat(a)$],
+    [`hat(a)`],
+    [$arrow(a)$],
+    [`arrow(a)`],
+  ),
+)
 
 If the decorated letter is $i$ or $j$ then some decorations need `dotless.i` and `dotless.j`, as in $arrow(dotless.i)$ with `arrow(dotless.i)`.
 Some authors use boldface for vectors: `bold(x)`.
@@ -236,40 +278,46 @@ Some authors use boldface for vectors: `bold(x)`.
 Entering `overline(x + y)` produces $overline(x + y)$, and `hat(x + y)` gives $hat(x + y)$.
 Comment on an expression as here (there is also `overbrace(..)`).
 
-#align(center, table(
-  columns: 2,
-  column-gutter: 1em,
-  [$ underbrace(x + y, |A|) $],
-  [
-    ```
-    underbrace(x + y, |A|)
-    ```
-  ],
-))
+#align(
+  center,
+  table(
+    columns: 2,
+    column-gutter: 1em,
+    [$ underbrace(x + y, |A|) $],
+    [
+      ```
+      underbrace(x + y, |A|)
+      ```
+    ],
+  ),
+)
 
 = Dots
 Use low dots in a list ${0, 1, 2, ...}$, entered as `{0, 1, 2, ...}`.
-Use centered dots in a sum or product $1 + dots.h.c + 100$, entered as  `1 + dots.h.c + 100`.
+Use centered dots in a sum or product $1 + dots.h.c + 100$, entered as `1 + dots.h.c + 100`.
 You can also get vertical dots `dots.v`, diagonal dots `dots.down` and anti-diagonal dots `dots.up`.
 
 = Roman names
 Just type them!
 
-#align(center, table(
-  columns: 6,
-  align: (right, left, right, left, right, left),
-  column-gutter: (1em, 1.5em, 1em, 1.5em, 1em),
-  [$sin$], [`sin`], [$sinh$], [`sinh`], [$arcsin$], [`arcsin`],
-  [$cos$], [`cos`], [$cosh$], [`cosh`], [$arccos$], [`arccos`],
-  [$tan$], [`tan`], [$tanh$], [`tanh`], [$arctan$], [`arctan`],
-  [$sec$], [`sec`], [$coth$], [`coth`], [$min$], [`min`],
-  [$csc$], [`csc`], [$det$], [`det`], [$max$], [`max`],
-  [$cot$], [`cot`], [$dim$], [`dim`], [$inf$], [`inf`],
-  [$exp$], [`exp`], [$ker$], [`ker`], [$sup$], [`sup`],
-  [$log$], [`log`], [$deg$], [`deg`], [$liminf$], [`liminf`],
-  [$ln$], [`ln`], [$arg$], [`arg`], [$limsup$], [`limsup`],
-  [$lg$], [`lg`], [$gcd$], [`gcd`], [$lim$], [`lim`],
-))
+#align(
+  center,
+  table(
+    columns: 6,
+    align: (right, left, right, left, right, left),
+    column-gutter: (1em, 1.5em, 1em, 1.5em, 1em),
+    [$sin$], [`sin`], [$sinh$], [`sinh`], [$arcsin$], [`arcsin`],
+    [$cos$], [`cos`], [$cosh$], [`cosh`], [$arccos$], [`arccos`],
+    [$tan$], [`tan`], [$tanh$], [`tanh`], [$arctan$], [`arctan`],
+    [$sec$], [`sec`], [$coth$], [`coth`], [$min$], [`min`],
+    [$csc$], [`csc`], [$det$], [`det`], [$max$], [`max`],
+    [$cot$], [`cot`], [$dim$], [`dim`], [$inf$], [`inf`],
+    [$exp$], [`exp`], [$ker$], [`ker`], [$sup$], [`sup`],
+    [$log$], [`log`], [$deg$], [`deg`], [$liminf$], [`liminf`],
+    [$ln$], [`ln`], [$arg$], [`arg`], [$limsup$], [`limsup`],
+    [$lg$], [`lg`], [$gcd$], [`gcd`], [$lim$], [`lim`],
+  ),
+)
 
 #let cosec = math.op("cosec")
 
@@ -280,47 +328,110 @@ If an operator you wish to use does not exist, you can create one using `math.op
 $ cosec x = 1/(sin x) $
 ```
 
-$ cosec x = 1/(sin x) $
+$ cosec x = 1 / (sin x) $
 
 = Other symbols
-#align(center, table(
-  columns: 6,
-  align: (right, left, right, left, right, left),
-  column-gutter: (0.5em, 1em, 0.5em, 1em, 0.5em),
-  [$<$], [`<`, `lt`], [$angle$], [`angle`], [$dot$], [`dot`],
-  [$<=$], [`<=`, `lt.eq`], [$angle.arc$], [`angle.arc`], [$plus.minus$], [`plus.minus`],
-  [$>$], [`>`, `gt`], [$ell$], [`ell`], [$minus.plus$], [`minus.plus`],
-  [$>=$], [`>=`, `gt.eq`], [$parallel$], [`parallel`], [$times$], [`times`],
-  [$!=$], [`!=`, `eq.not`], [$45 degree$], [`45 degree`], [$div$], [`div`],
-  [$<<$], [`<<`, `lt.double`], [$tilde.equiv$], [`tilde.equiv`], [$*$], [`*`, `ast`],
-  [$>>$], [`>>`, `gt.double`], [$tilde.nequiv$], [`tilde.nequiv`], [$divides$], [`divides`],
-  [$approx$], [`approx`], [$tilde$], [`tilde`], [$divides.not$], [`divides.not`],
-  [$asymp$], [`asymp`], [$tilde.eq$], [`tilde.eq`], [$n!$], [`n!`],
-  [$equiv$], [`equiv`], [$tilde.not$], [`tilde.not`], [$diff$], [`diff`],
-  [$prec$], [`prec`], [$plus.circle$], [`plus.circle`], [$nabla$], [`nabla`],
-  [$prec.eq$], [`prec.eq`], [$minus.circle$], [`minus.cirle`], [$planck.reduce$], [`planck.reduce`],
-  [$succ$], [`succ`], [$dot.circle$], [`dot.circle`], [$compose$], [`compose`],
-  [$succ.eq$], [`succ.eq`], [$times.circle$], [`times.circle`], [$star$], [`star`],
-  [$prop$], [`prop`], [$\u{2298}$], [`\u{2298}` @tricky], [$sqrt("")$], [`sqrt("")`],
-  [$\u{2250}$], [`\u{2250}` @tricky], [$harpoon.tr$], [`harpoon.tr`], [$checkmark$], [`checkmark`],
-))
+#align(
+  center,
+  table(
+    columns: 6,
+    align: (right, left, right, left, right, left),
+    column-gutter: (0.5em, 1em, 0.5em, 1em, 0.5em),
+    [$<$], [`<`, `lt`], [$angle$], [`angle`], [$dot$], [`dot`],
+    [$<=$],
+    [`<=`, `lt.eq`],
+    [$angle.arc$],
+    [`angle.arc`],
+    [$plus.minus$],
+    [`plus.minus`],
+
+    [$>$], [`>`, `gt`], [$ell$], [`ell`], [$minus.plus$], [`minus.plus`],
+    [$>=$], [`>=`, `gt.eq`], [$parallel$], [`parallel`], [$times$], [`times`],
+    [$!=$], [`!=`, `eq.not`], [$45 degree$], [`45 degree`], [$div$], [`div`],
+    [$<<$],
+    [`<<`, `lt.double`],
+    [$tilde.equiv$],
+    [`tilde.equiv`],
+    [$*$],
+    [`*`, `ast`],
+
+    [$>>$],
+    [`>>`, `gt.double`],
+    [$tilde.nequiv$],
+    [`tilde.nequiv`],
+    [$divides$],
+    [`divides`],
+
+    [$approx$],
+    [`approx`],
+    [$tilde$],
+    [`tilde`],
+    [$divides.not$],
+    [`divides.not`],
+
+    [$asymp$], [`asymp`], [$tilde.eq$], [`tilde.eq`], [$n!$], [`n!`],
+    [$equiv$], [`equiv`], [$tilde.not$], [`tilde.not`], [$diff$], [`diff`],
+    [$prec$], [`prec`], [$plus.circle$], [`plus.circle`], [$nabla$], [`nabla`],
+    [$prec.eq$],
+    [`prec.eq`],
+    [$minus.circle$],
+    [`minus.cirle`],
+    [$planck.reduce$],
+    [`planck.reduce`],
+
+    [$succ$],
+    [`succ`],
+    [$dot.circle$],
+    [`dot.circle`],
+    [$compose$],
+    [`compose`],
+
+    [$succ.eq$],
+    [`succ.eq`],
+    [$times.circle$],
+    [`times.circle`],
+    [$star$],
+    [`star`],
+
+    [$prop$],
+    [`prop`],
+    [$\u{2298}$],
+    [`\u{2298}` @tricky],
+    [$sqrt("")$],
+    [`sqrt("")`],
+
+    [$\u{2250}$],
+    [`\u{2250}` @tricky],
+    [$harpoon.tr$],
+    [`harpoon.tr`],
+    [$checkmark$],
+    [`checkmark`],
+  ),
+)
 
 Use `a divides b` for the divides relation, $a divides b$, and `a divides.not b` for the negation, $a divides.not b$.
 Use `|` to get set builder notation ${a in S | a "is odd"}$ with `{a in S | a "is odd"}`.
 
 = Arrows
-#align(center, table(
-  columns: 4,
-  align: (right, left, right, left),
-  column-gutter: (1em, 1.5em, 1em),
-  [$->$], [`->`, `arrow.r`], [$|->$], [`|->`, `arrow.r.bar`],
-  [$arrow.r.not$], [`arrow.r.not`], [$arrow.r.long.bar$], [`arrow.r.long.bar`],
-  [$-->$], [`-->`, `arrow.r.long`], [$<-$], [`<-`, `arrow.l`],
-  [$=>$], [`=>`, `arrow.r.double`], [$<->$], [`<->`, `arrow.l.r`],
-  [$arrow.r.double.not$], [`arrow.r.double.not`], [$arrow.b$], [`arrow.b`],
-  [$==>$], [`==>`, `arrow.r.double.long`], [$arrow.t$], [`arrow.t`],
-  [$arrow.squiggly$], [`arrow.squiggly`], [$arrow.t.b$], [`arrow.t.b`],
-))
+#align(
+  center,
+  table(
+    columns: 4,
+    align: (right, left, right, left),
+    column-gutter: (1em, 1.5em, 1em),
+    [$->$], [`->`, `arrow.r`], [$|->$], [`|->`, `arrow.r.bar`],
+    [$arrow.r.not$],
+    [`arrow.r.not`],
+    [$arrow.r.long.bar$],
+    [`arrow.r.long.bar`],
+
+    [$-->$], [`-->`, `arrow.r.long`], [$<-$], [`<-`, `arrow.l`],
+    [$=>$], [`=>`, `arrow.r.double`], [$<->$], [`<->`, `arrow.l.r`],
+    [$arrow.r.double.not$], [`arrow.r.double.not`], [$arrow.b$], [`arrow.b`],
+    [$==>$], [`==>`, `arrow.r.double.long`], [$arrow.t$], [`arrow.t`],
+    [$arrow.squiggly$], [`arrow.squiggly`], [$arrow.t.b$], [`arrow.t.b`],
+  ),
+)
 
 The right arrows in the first column have matching left arrows, such as `arrow.l.not`, and there are some other matches for down arrows, etc.
 
@@ -331,99 +442,131 @@ $ sum_(j = 0)^3 j^2 wide integral_(x = 0)^3 x^2 dif x $
 
 These do the same.
 
-#align(center, table(
-  columns: 4,
-  align: (right, left, right, left),
-  column-gutter: (1em, 1.5em, 1em),
-  row-gutter: 0.5em,
-  [$integral$], [`integral`], [$integral.double$], [`integral.double`],
-  [$integral.triple$], [`integral.triple`], [$integral.cont$], [`integral.cont`],
-  [$union.big$], [`union.big`], [$inter.big$], [`inter.big`],
-))
+#align(
+  center,
+  table(
+    columns: 4,
+    align: (right, left, right, left),
+    column-gutter: (1em, 1.5em, 1em),
+    row-gutter: 0.5em,
+    [$integral$], [`integral`], [$integral.double$], [`integral.double`],
+    [$integral.triple$],
+    [`integral.triple`],
+    [$integral.cont$],
+    [`integral.cont`],
+
+    [$union.big$], [`union.big`], [$inter.big$], [`inter.big`],
+  ),
+)
 
 = Fences
-#align(center, table(
-  columns: 6,
-  align: (right, left, right, left, right, left),
-  column-gutter: (1em, 1.5em, 1em, 1.5em, 1em),
-  row-gutter: 0.5em,
-  [$()$], [`()`], [$angle.l angle.r$], [`angle.l angle.r`], [$abs("")$], [`abs("")`],
-  [$[]$], [`[]`], [$floor("")$], [`floor("")`], [$norm("")$], [`norm("")`],
-  [${}$], [`{}`], [$ceil("")$], [`ceil("")`],
-))
+#align(
+  center,
+  table(
+    columns: 6,
+    align: (right, left, right, left, right, left),
+    column-gutter: (1em, 1.5em, 1em, 1.5em, 1em),
+    row-gutter: 0.5em,
+    [$()$],
+    [`()`],
+    [$angle.l angle.r$],
+    [`angle.l angle.r`],
+    [$abs("")$],
+    [`abs("")`],
+
+    [$[]$], [`[]`], [$floor("")$], [`floor("")`], [$norm("")$], [`norm("")`],
+    [${}$], [`{}`], [$ceil("")$], [`ceil("")`],
+  ),
+)
 
 Fix the size with the `lr` function.
 
-#align(center, table(
-  columns: 2,
-  column-gutter: 1em,
-  [$ lr([sum_(k = 0)^n e^(k^2)], size: #50%) $],
-  [
-    ```
-    lr([sum_(k = 0)^n e^(k^2)], size: #50%)
-    ```
-  ],
-))
+#align(
+  center,
+  table(
+    columns: 2,
+    column-gutter: 1em,
+    [$ lr([sum_(k = 0)^n e^(k^2)], size: #50%) $],
+    [
+      ```
+      lr([sum_(k = 0)^n e^(k^2)], size: #50%)
+      ```
+    ],
+  ),
+)
 
 To have them grow with the enclosed formula, also use the `lr` function.
 
-#align(center, table(
-  columns: 2,
-  column-gutter: 1em,
-  [$ lr(angle.l i, 2^(2^i) angle.r) $],
-  [
-    ```
-    lr(angle.l i, 2^(2^i) angle.r)
-    ```
-  ],
-))
+#align(
+  center,
+  table(
+    columns: 2,
+    column-gutter: 1em,
+    [$ lr(angle.l i, 2^(2^i) angle.r) $],
+    [
+      ```
+      lr(angle.l i, 2^(2^i) angle.r)
+      ```
+    ],
+  ),
+)
 
 Fences scale by default if entered directly as codepoints, and don't scale automatically if entered as symbol notation.
 
-#align(center, table(
-  columns: 2,
-  align: (right + horizon, left + horizon),
-  column-gutter: 1em,
-  [$ (1 / n^(alpha)) $],
-  [
-    ```
-    (1 / n^(alpha))
-    ```
-  ],
-  [$ paren.l 1 / n^(alpha) paren.r $],
-  [
-    ```
-    paren.l 1 / n^(alpha) paren.r
-    ```
-  ],
-))
+#align(
+  center,
+  table(
+    columns: 2,
+    align: (right + horizon, left + horizon),
+    column-gutter: 1em,
+    [$ (1 / n^(alpha)) $],
+    [
+      ```
+      (1 / n^(alpha))
+      ```
+    ],
+
+    [$ paren.l 1 / n^(alpha) paren.r $],
+    [
+      ```
+      paren.l 1 / n^(alpha) paren.r
+      ```
+    ],
+  ),
+)
 
 The `lr` function also allows to scale unmatched delimiters and one-side fences.
 
-#align(center, table(
-  columns: 2,
-  column-gutter: 1em,
-  [$ lr(frac(dif f, dif x) |)_(x_0) $],
-  [
-    ```
-    lr(frac(dif f, dif x) |)_(x_0)
-    ```
-  ],
-))
+#align(
+  center,
+  table(
+    columns: 2,
+    column-gutter: 1em,
+    [$ lr(frac(dif f, dif x) |)_(x_0) $],
+    [
+      ```
+      lr(frac(dif f, dif x) |)_(x_0)
+      ```
+    ],
+  ),
+)
 
 = Arrays, Matrices
 Get a matrix with the `mat` function. You can pass an array to it.
 
-#align(center, table(
-  columns: 2,
-  column-gutter: 1em,
-  [$ mat(a, b; c, d) $],
-  [
-    ```
-    $ mat(a, b; c, d) $
-    ```
-  ],
-))
+#align(
+  center,
+  table(
+    columns: 2,
+    column-gutter: 1em,
+    [$ mat(a, b; c, d) $],
+    [
+      ```
+      $ mat(a, b; c, d) $
+      ```
+    ],
+  ),
+)
 
 In Typst, #link("https://typst.app/docs/reference/types/array")[array] is a sequence of values,
 while in #LaTeX, array is a matrix without fences, which is `$mat(delim: #none, ..)$` in Typst.
@@ -432,24 +575,29 @@ For the determinant use `|A|`, text operator $det$ `det` or `mat(delim: "|", ..)
 
 Definition by cases can be easily obtained with the `cases` function.
 
-#align(center, table(
-  columns: 2,
-  column-gutter: 1em,
-  [
-    $ f_n = cases(
+#align(
+  center,
+  table(
+    columns: 2,
+    column-gutter: 1em,
+    [
+      $
+        f_n = cases(
       a &"if" n = 0,
       r dot f_(n - 1) &"else"
-    ) $
-  ],
-  [
-    ```
-    $ f_n = cases(
-      a &"if" n = 0,
-      r dot f_(n - 1) &"else"
-    ) $
-    ```
-  ]
-))
+    )
+      $
+    ],
+    [
+      ```
+      $ f_n = cases(
+        a &"if" n = 0,
+        r dot f_(n - 1) &"else"
+      ) $
+      ```
+    ],
+  ),
+)
 
 = Spacing in mathematics
 Improve $sqrt(2) x$ to $sqrt(2) thin x$ with a thin space, as in `sqrt(2) thin x`.
@@ -461,48 +609,61 @@ For example, use `#h(-0.1667em)` for `\!` in #LaTeX.
 = Displayed equations
 Display equations in a block level using `$ ... $` with at least one space separating the math content and the `$`.
 
-#align(center, table(
-  columns: 2,
-  column-gutter: 1em,
-  [$ S = k dot lg W $],
-  [
-    ```
-    $ S = k dot lg W $
-    ```
-  ],
-))
+#align(
+  center,
+  table(
+    columns: 2,
+    column-gutter: 1em,
+    [$ S = k dot lg W $],
+    [
+      ```
+      $ S = k dot lg W $
+      ```
+    ],
+  ),
+)
 
 You can break into multiple lines.
 
-#align(center, table(
-  columns: 2,
-  column-gutter: 1em,
-  [
-    $ sin(x) = x - x^3 / 3! \
-      + x^5 / 5! - dots.h.c $
-  ],
-  [
-    ```
-    $ sin(x) = x - x^3 / 3! \
-        + x^5 / 5! - dots.h.c $
-    ```
-  ],
-))
+#align(
+  center,
+  table(
+    columns: 2,
+    column-gutter: 1em,
+    [
+      $
+        sin(x) = x - x^3 / 3! \
+        + x^5 / 5! - dots.h.c
+      $
+    ],
+    [
+      ```
+      $ sin(x) = x - x^3 / 3! \
+          + x^5 / 5! - dots.h.c $
+      ```
+    ],
+  ),
+)
 
 Align equations using `&`
 
-#align(center, table(
-  columns: 2,
-  column-gutter: 1em,
-  [
+#align(
+  center,
+  table(
+    columns: 2,
+    column-gutter: 1em,
+    [
+      $
+        nabla dot bold(D) &= rho \
+        nabla dot bold(B) &= 0
+      $
+    ],
+    ```
     $ nabla dot bold(D) &= rho \
       nabla dot bold(B) &= 0 $
-  ],
-  ```
-  $ nabla dot bold(D) &= rho \
-    nabla dot bold(B) &= 0 $
-  ```,
-))
+    ```,
+  ),
+)
 
 (the left or right side of an alignment can be empty).
 Get a numbered version by `#set math.equation(numbering: ..)`.
@@ -510,36 +671,43 @@ Get a numbered version by `#set math.equation(numbering: ..)`.
 = Calculus examples
 The last three here are display style.
 
-#align(center, table(
-  columns: 2,
-  column-gutter: 1em,
-  [$ f: RR -> RR $],
-  [
-    ```
-    f: RR -> RR
-    ```
-  ],
-  [$ 9.8 thin "m/s"^2 $],
-  [`9.8 thin "m/s"^2` @tricky],
-  [$ lim_(h->0) (f(x+h)-f(x))/h $],
-  [
-    ```
-    lim_(h -> 0) (f(x + h) - f(x)) / h
-    ```
-  ],
-  [$ integral x^2 dif x = x^3 \/ 3 + C $],
-  [
-    ```
-    integral x^2 dif x = x^3 \/ 3 + C
-    ```
-  ],
-  [$ nabla = bold(i) dif / (dif x) + bold(j) dif / (dif y) + bold(k) dif / (dif z) $],
-  [
-    ```
-    nabla = bold(i) dif / (dif x) + bold(j) dif / (dif y) + bold(k) dif / (dif z)
-    ```
-  ],
-))
+#align(
+  center,
+  table(
+    columns: 2,
+    column-gutter: 1em,
+    [$ f: RR -> RR $],
+    [
+      ```
+      f: RR -> RR
+      ```
+    ],
+
+    [$ 9.8 thin "m/s"^2 $], [`9.8 thin "m/s"^2` @tricky],
+    [$ lim_(h->0) (f(x+h)-f(x)) / h $],
+    [
+      ```
+      lim_(h -> 0) (f(x + h) - f(x)) / h
+      ```
+    ],
+
+    [$ integral x^2 dif x = x^3 \/ 3 + C $],
+    [
+      ```
+      integral x^2 dif x = x^3 \/ 3 + C
+      ```
+    ],
+
+    [$
+        nabla = bold(i) dif / (dif x) + bold(j) dif / (dif y) + bold(k) dif / (dif z)
+      $],
+    [
+      ```
+      nabla = bold(i) dif / (dif x) + bold(j) dif / (dif y) + bold(k) dif / (dif z)
+      ```
+    ],
+  ),
+)
 
 = Discrete mathematics examples
 For modulo, there is a symbol $equiv$ from `equiv` and a text operator $mod$ from `mod`.
@@ -550,28 +718,33 @@ This resizes to be bigger in a display.
 For permutations use $n^(underline(r))$ from `n^(underline(r))` (some authors use $P(n, r)$, or $""_n P_r$ from `""_n P_r`).
 
 = Statistics examples
-#align(center, table(
-  columns: 2,
-  column-gutter: 1em,
-  [$ sigma^2 = sqrt(sum(x_i - mu)^2 \/ N) $],
-  [
-    ```
-    sigma^2 = sqrt(sum(x_i - mu)^2 \/ N)
-    ```
-  ],
-  [$ E(X) = mu_X = sum(x_i - P(x_i)) $],
-  [
-    ```
-    E(X) = mu_X = sum(x_i - P(x_i))
-    ```
-  ],
-  [$ 1 / sqrt(2 sigma^2 pi) e^(- (x - mu)^2 / (2 sigma^2)) $],
-  [
-    ```
-    1 / sqrt(2 sigma^2 pi) e^(- (x - mu)^2 / (2 sigma^2))
-    ```
-  ]
-))
+#align(
+  center,
+  table(
+    columns: 2,
+    column-gutter: 1em,
+    [$ sigma^2 = sqrt(sum(x_i - mu)^2 \/ N) $],
+    [
+      ```
+      sigma^2 = sqrt(sum(x_i - mu)^2 \/ N)
+      ```
+    ],
+
+    [$ E(X) = mu_X = sum(x_i - P(x_i)) $],
+    [
+      ```
+      E(X) = mu_X = sum(x_i - P(x_i))
+      ```
+    ],
+
+    [$ 1 / sqrt(2 sigma^2 pi) e^(- (x - mu)^2 / (2 sigma^2)) $],
+    [
+      ```
+      1 / sqrt(2 sigma^2 pi) e^(- (x - mu)^2 / (2 sigma^2))
+      ```
+    ],
+  ),
+)
 
 = For more
 See also the Typst Documentation at #link("https://typst.app/docs").

--- a/undergradmath.typ
+++ b/undergradmath.typ
@@ -683,7 +683,7 @@ The last three here are display style.
       ```
     ],
 
-    [$ 9.8 thin "m/s"^2 $], [`9.8 thin "m/s"^2` @tricky],
+    [$ 9.8 thin "m" slash "s"^2 $], [`9.8 thin "m" slash "s"^2` @tricky],
     [$ lim_(h->0) (f(x+h)-f(x)) / h $],
     [
       ```

--- a/undergradmath.typ
+++ b/undergradmath.typ
@@ -295,7 +295,7 @@ $ cosec x = 1/(sin x) $
   [$<<$], [`<<`, `lt.double`], [$tilde.equiv$], [`tilde.equiv`], [$*$], [`*`, `ast`],
   [$>>$], [`>>`, `gt.double`], [$tilde.nequiv$], [`tilde.nequiv`], [$divides$], [`divides`],
   [$approx$], [`approx`], [$tilde$], [`tilde`], [$divides.not$], [`divides.not`],
-  [$\u{224D}$], [`\u{224D}` @tricky], [$tilde.eq$], [`tilde.eq`], [$n!$], [`n!`],
+  [$asymp$], [`asymp`], [$tilde.eq$], [`tilde.eq`], [$n!$], [`n!`],
   [$equiv$], [`equiv`], [$tilde.not$], [`tilde.not`], [$diff$], [`diff`],
   [$prec$], [`prec`], [$plus.circle$], [`plus.circle`], [$nabla$], [`nabla`],
   [$prec.eq$], [`prec.eq`], [$minus.circle$], [`minus.cirle`], [$planck.reduce$], [`planck.reduce`],

--- a/undergradmath.typ
+++ b/undergradmath.typ
@@ -181,7 +181,7 @@ Get script letters, such as $cal(P)$ from `$cal(P)$`, by changing the `stylistic
   align: (right, left, right, left, right, left),
   column-gutter: (1em, 1.5em, 1em, 1.5em, 1em),
   [$union$], [`union`], [$RR$], [`RR`, `bb(R)`], [$forall$], [`forall`],
-  [$sect$], [`sect`], [$bb(Z)$], [`ZZ`, `bb(Z)`], [$exists$], [`exists`],
+  [$inter$], [`inter`], [$bb(Z)$], [`ZZ`, `bb(Z)`], [$exists$], [`exists`],
   [$subset$], [`subset`], [$bb(Q)$], [`QQ`, `bb(Q)`], [$not$], [`not`],
   [$subset.eq$], [`subset.eq`], [$bb(N)$], [`NN`, `bb(N)`], [$or$], [`or`],
   [$supset$], [`supset`], [$bb(C)$], [`CC`, `bb(C)`], [$and$], [`and`],
@@ -338,7 +338,7 @@ These do the same.
   row-gutter: 0.5em,
   [$integral$], [`integral`], [$integral.double$], [`integral.double`],
   [$integral.triple$], [`integral.triple`], [$integral.cont$], [`integral.cont`],
-  [$union.big$], [`union.big`], [$sect.big$], [`sect.big`],
+  [$union.big$], [`union.big`], [$inter.big$], [`inter.big`],
 ))
 
 = Fences


### PR DESCRIPTION
Let's have an updated version with the latest version of Typst (0.13.1).

- Use `context` expression instead of `style` (removed in [Typst 0.13.0]) for $\mathrm{\TeX}$ and $\mathrm{\LaTeX}$.
- Replace the deprecated (as from [Typst 0.13.0]) `sect` with `inter` for intersections $\cap$.
- Replace the tricky `\u{224D}` with `asymp` (available as from [Typst 0.13.0]) for $\asymp$ (`\asymp` in LaTeX).

[Typst 0.13.0]: https://typst.app/docs/changelog/0.13.0/